### PR TITLE
Added UTF-8 encoding to prevent charmap error on Emojis

### DIFF
--- a/tripadvisorSelenium.ipynb
+++ b/tripadvisorSelenium.ipynb
@@ -142,7 +142,7 @@
    "outputs": [],
    "source": [
     "# open the file to save the review\n",
-    "csvFile = open(\"/Users/gius/Desktop/reviews.csv\", 'a')\n",
+    "csvFile = open(\"/Users/gius/Desktop/reviews.csv\", 'a', encoding='utf-8')\n",
     "csvWriter = csv.writer(csvFile)"
    ]
   },


### PR DESCRIPTION
Without passing `encoding='utf-8'` to the `open()` function of the CSV this error is very likely to happen:
 **'charmap' codec can't encode character '\U0001f60d' in position 107: character maps to <undefined>**

(this specific error happens on the Colosseum page since this '😍' emoji is found in the reviews)